### PR TITLE
Yubikey Realm for Glassfish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,12 @@
                 <artifactId>vt-ldap</artifactId>
                 <version>3.3.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.security</groupId>
+            <artifactId>security</artifactId>
+            <version>3.1.1</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/yubico/jaas/YubikeyGFLoginModule.java
+++ b/src/main/java/com/yubico/jaas/YubikeyGFLoginModule.java
@@ -1,0 +1,94 @@
+/*
+ * To change this template, choose Tools | Templates and open the template in
+ * the editor.
+ */
+package com.yubico.jaas;
+
+import com.sun.appserv.security.AppservPasswordLoginModule;
+import com.sun.enterprise.security.auth.realm.BadRealmException;
+import com.sun.enterprise.security.auth.realm.NoSuchRealmException;
+import com.sun.enterprise.security.auth.realm.file.FileRealm;
+import com.yubico.client.v2.YubicoClient;
+import com.yubico.client.v2.YubicoResponse;
+import com.yubico.client.v2.YubicoResponseStatus;
+import com.yubico.jaas.impl.YubikeyToUserMapImpl;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.security.auth.login.LoginException;
+
+/**
+ *
+ * @author duncan
+ */
+public class YubikeyGFLoginModule extends AppservPasswordLoginModule {
+
+    private static final String ROLES_FILE = "rolesfile";
+    
+    private YubikeyToUserMapImpl ykmap;
+    private YubicoClient yc;
+    private String publicId;
+        
+    @Override
+    public void authenticateUser() throws LoginException {
+        if (_passwd.length < 32) {
+            Logger.getLogger(YubikeyGFLoginModule.class.getName()).log(Level.INFO, "Skipping token, not a valid YubiKey OTP (too short, {0} < 32)", _passwd.length);
+            throw new LoginException("YubiKey OTP authentication failed - no OTPs supplied");
+        }
+
+        ykmap = new YubikeyToUserMapImpl();
+        ykmap.setOptions(_options);
+                
+        if (validate_otps(_passwd, _username)) {
+            String[] grpList = getGroupList(_username, publicId);
+            commitUserAuthentication(grpList);
+            return ;
+        }
+
+        throw new LoginException("YubiKey OTP authentication failed");        
+    }
+
+    private boolean validate_otps(char[] otp, String _username) {
+        boolean validated = false;
+
+        String password = String.valueOf(otp);
+        Logger.getLogger(YubikeyGFLoginModule.class.getName()).log(Level.FINE, "Checking OTP {0}", password);
+
+        yc = YubicoClient.getClient(4711);
+        YubicoResponse ykr = this.yc.verify(password);
+        
+        if (ykr != null) {
+            Logger.getLogger(YubikeyGFLoginModule.class.getName()).log(Level.FINE, "OTP {0} verify result : {1}", new Object[]{password, ykr.getStatus().toString()});
+            if (ykr.getStatus() == YubicoResponseStatus.OK) {
+                publicId = YubicoClient.getPublicId(password);
+                Logger.getLogger(YubikeyGFLoginModule.class.getName()).log(Level.INFO, "OTP verified successfully (YubiKey client {0})", publicId);
+                validated = true;
+            } else {
+                Logger.getLogger(YubikeyGFLoginModule.class.getName()).log(Level.FINER, "OTP validation returned {0}", ykr.getStatus().toString());
+            }
+        } else {
+            Logger.getLogger(YubikeyGFLoginModule.class.getName()).log(Level.WARNING, "null YubicoResponse");
+        }
+
+        return validated;        
+    }
+
+    private String[] getGroupList(String _username, String publicId) throws LoginException {
+        Logger.getLogger(YubikeyGFLoginModule.class.getName()).log(Level.FINE, "Check if YubiKey {0} belongs to user {1}", new Object[]{publicId, _username});
+        FileRealm fileRealm;
+        try {
+            fileRealm = new FileRealm(_options.get(ROLES_FILE).toString());
+            String[] roles = fileRealm.authenticate(_username, publicId.toCharArray());
+            if (roles == null){
+                throw new LoginException("YubiKey " + publicId + " NOT registered to user "+ _username);
+            }
+            return roles;
+        } catch (BadRealmException ex) {
+            Logger.getLogger(YubikeyGFLoginModule.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (NoSuchRealmException ex) {
+            Logger.getLogger(YubikeyGFLoginModule.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        
+        return new String[]{};
+    }
+    
+}

--- a/src/main/java/com/yubico/jaas/YubikeyRealm.java
+++ b/src/main/java/com/yubico/jaas/YubikeyRealm.java
@@ -1,0 +1,52 @@
+/*
+ * To change this template, choose Tools | Templates and open the template in
+ * the editor.
+ */
+package com.yubico.jaas;
+
+import com.sun.appserv.security.AppservRealm;
+import com.sun.enterprise.security.auth.realm.BadRealmException;
+import com.sun.enterprise.security.auth.realm.InvalidOperationException;
+import com.sun.enterprise.security.auth.realm.NoSuchRealmException;
+import com.sun.enterprise.security.auth.realm.NoSuchUserException;
+import java.util.Enumeration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ *
+ * @author duncan
+ */
+public class YubikeyRealm extends AppservRealm{
+
+    private String jaasCtxName;
+    private String startWith;
+    
+    @Override
+    protected void init(Properties props) throws BadRealmException, NoSuchRealmException {
+        jaasCtxName = props.getProperty("jaas-context", "yubikeyRealm");
+        startWith = props.getProperty("startWith", "z");
+    }
+
+    @Override
+    public String getJAASContext() { 
+        return jaasCtxName;
+    }
+    
+    @Override
+    public String getAuthType() {
+        return "Yubikey Realm"; 
+    }
+
+    @Override
+    public Enumeration getGroupNames(String string) throws InvalidOperationException, NoSuchUserException {
+        List groupNames = new LinkedList(); 
+        return (Enumeration) groupNames;
+    }
+    
+    public String getStartWith() { 
+        return startWith; 
+    }
+    
+}


### PR DESCRIPTION
Hi,
Just to let you know I made something for Glassfish.
Glassfish uses a realm, which provides the user credentials instead of callback handlers.

If I am correct, the default YubikeyLoginModule doesn't work with GF3.1, because the use of callback handlers triggers a loop to get the user credentials again, and again, and again....

Glassfsh provides a Realm for LoginModules, which (already) hold the user credentials.

Regards,
Duncan
