### PR TITLE
Add JACC feature for Form-Based Authentication

### DIFF
--- a/jaas/README
+++ b/jaas/README
@@ -32,6 +32,8 @@ https://upgrade.yubico.com/getapikey/
    sync_policy          default: none, let the server decide. a value between 0
                         and 100 indicating the percentage of synchronization
                         required by the client.
+   jacc			default: false, if true module picks up the otp from j_otp
+   			FORM authentication too
 
   Example configuration :
 

--- a/jaas/pom.xml
+++ b/jaas/pom.xml
@@ -39,6 +39,16 @@
       <artifactId>commons-codec</artifactId>
       <version>1.4</version>
     </dependency>
+    <dependency>
+	  <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-jacc_1.4_spec</artifactId>
+      <version>1.0</version>
+    </dependency>
+	<dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-servlet_3.0_spec</artifactId>
+      <version>1.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/jaas/src/main/java/com/yubico/jaas/YubikeyLoginModule.java
+++ b/jaas/src/main/java/com/yubico/jaas/YubikeyLoginModule.java
@@ -67,16 +67,16 @@ public class YubikeyLoginModule implements LoginModule {
 	/* Options for this class.
 	 * Note that the options map is shared with other classes, like YubikeyToUserMap.
 	 */
-	public static final String OPTION_YUBICO_CLIENT_ID			= "clientId";
-	public static final String OPTION_YUBICO_CLIENT_KEY         = "clientKey";
-	public static final String OPTION_YUBICO_ID_REALM			= "id_realm";
+	public static final String OPTION_YUBICO_CLIENT_ID		= "clientId";
+	public static final String OPTION_YUBICO_CLIENT_KEY         	= "clientKey";
+	public static final String OPTION_YUBICO_ID_REALM		= "id_realm";
 	public static final String OPTION_YUBICO_SOFT_FAIL_NO_OTPS	= "soft_fail_on_no_otps";
-	public static final String OPTION_YUBICO_WSAPI_URLS			= "wsapi_urls";
-	public static final String OPTION_YUBICO_USERMAP_CLASS      = "usermap_class";
-	public static final String OPTION_YUBICO_SYNC_POLICY        = "sync_policy";
-	public static final String OPTION_YUBICO_JACC			 	= "jacc";
+	public static final String OPTION_YUBICO_WSAPI_URLS		= "wsapi_urls";
+	public static final String OPTION_YUBICO_USERMAP_CLASS  	= "usermap_class";
+	public static final String OPTION_YUBICO_SYNC_POLICY        	= "sync_policy";
+	public static final String OPTION_YUBICO_JACC		 	= "jacc";
 	public static final String JACC_ATTR_WEB_REQUEST_KEY 		= "javax.servlet.http.HttpServletRequest";
-	public static final String HTTP_REQUEST_ATTR_TOTP 			= "j_otp";
+	public static final String HTTP_REQUEST_ATTR_TOTP 		= "j_otp";
 
 	/* JAAS stuff */
 	private Subject subject;
@@ -328,9 +328,7 @@ public class YubikeyLoginModule implements LoginModule {
 				String j_otp = request.getParameter(HTTP_REQUEST_ATTR_TOTP);
 				
 				if (j_otp.length() < 32) {
-					log.debug(
-							"Skipping token from j_otp, not a valid YubiKey OTP (too short, {} < 32)",
-							j_otp.length());
+					log.debug("Skipping token from j_otp, not a valid YubiKey OTP (too short, {} < 32)",j_otp.length());
 				} else {
 					result.add(j_otp);
 				}

--- a/jaas/src/main/java/com/yubico/jaas/YubikeyLoginModule.java
+++ b/jaas/src/main/java/com/yubico/jaas/YubikeyLoginModule.java
@@ -327,7 +327,7 @@ public class YubikeyLoginModule implements LoginModule {
 						.getContext(JACC_ATTR_WEB_REQUEST_KEY);
 				String j_otp = request.getParameter(HTTP_REQUEST_ATTR_TOTP);
 				
-				if (j_otp.length() < 32) {
+				if (j_otp == null || j_otp.length() < 32) {
 					log.debug("Skipping token from j_otp, not a valid YubiKey OTP (too short, {} < 32)",j_otp.length());
 				} else {
 					result.add(j_otp);


### PR DESCRIPTION
This feature provides the possibility to pick up a otp from an extra field in Form-Based Authentication.
Just add j_opt input text into j_security_check  form like this
&lt;form action="j_security_check" method="POST"&gt;
  &lt;input type="text" name="j_username" /&gt;
  &lt;input type="secret" name="j_password" /&gt;
  &lt;input type="text" name="j_opt" /&gt;
&lt;/form&gt;
you can chain this module with an other login module to provide an 2nd factor authentication
http://docs.oracle.com/javaee/6/tutorial/doc/glxce.html