### PR TITLE
Removed commons-codec and replaced it with a native Base64 implementation.

### DIFF
--- a/jaas/src/main/java/com/yubico/jaas/HttpOathOtpLoginModule.java
+++ b/jaas/src/main/java/com/yubico/jaas/HttpOathOtpLoginModule.java
@@ -29,14 +29,8 @@
  */
 package com.yubico.jaas;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
@@ -45,10 +39,15 @@ import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
-
-import org.apache.commons.codec.binary.Base64;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import javax.xml.bind.DatatypeConverter;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A JAAS module for verifying OATH OTPs (One Time Passwords) using
@@ -177,7 +176,7 @@ public class HttpOathOtpLoginModule implements LoginModule {
 	private boolean verify_otp(String userName, String otp) {
 		try {
 			String authString = userName + ":" + otp;
-			String authStringEnc = Base64.encodeBase64URLSafeString(authString.getBytes());
+			String authStringEnc = DatatypeConverter.printString(authString);
 
 			URL url = new URL(this.protectedUrl);
 			URLConnection conn = url.openConnection();

--- a/v2client/pom.xml
+++ b/v2client/pom.xml
@@ -41,11 +41,6 @@
       <version>1.6.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.4</version>
-    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/v2client/src/main/java/com/yubico/client/v2/Signature.java
+++ b/v2client/src/main/java/com/yubico/client/v2/Signature.java
@@ -31,16 +31,14 @@ package com.yubico.client.v2;
 	Written by Simon Buckle <simon@webteq.eu>, September 2011.
 */
 
-import java.io.UnsupportedEncodingException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
+import com.yubico.client.v2.exceptions.YubicoSignatureException;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-
-import org.apache.commons.codec.binary.Base64;
-
-import com.yubico.client.v2.exceptions.YubicoSignatureException;
+import javax.xml.bind.DatatypeConverter;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 
 public class Signature {
 
@@ -54,7 +52,7 @@ public class Signature {
 			mac.init(signingKey);        
 			byte[] raw = mac.doFinal(data.getBytes("UTF-8"));
 			// Base64 encode the result, use old API call to work on android
-			return new String(Base64.encodeBase64(raw));
+			return DatatypeConverter.printBase64Binary(raw);
 		} catch (NoSuchAlgorithmException e) {
 			throw new YubicoSignatureException("No such algorithm (HMAC_SHA1?)", e);
 		} catch (InvalidKeyException e) {

--- a/v2client/src/main/java/com/yubico/client/v2/YubicoClient.java
+++ b/v2client/src/main/java/com/yubico/client/v2/YubicoClient.java
@@ -33,10 +33,11 @@
 
 package com.yubico.client.v2;
 
-import com.yubico.client.v2.exceptions.YubicoVerificationException;
 import com.yubico.client.v2.exceptions.YubicoValidationFailure;
+import com.yubico.client.v2.exceptions.YubicoVerificationException;
 import com.yubico.client.v2.impl.YubicoClientImpl;
-import org.apache.commons.codec.binary.Base64;
+
+import javax.xml.bind.DatatypeConverter;
 
 /**
  * Base class for doing YubiKey validations using version 2 of the validation protocol.
@@ -98,7 +99,7 @@ public abstract class YubicoClient {
      * @see YubicoClient#setClientId(Integer)
      */
     public void setKey(String key) {
-        this.key = Base64.decodeBase64(key.getBytes());
+        this.key = DatatypeConverter.parseBase64Binary(key);
     }
     
     /**
@@ -107,7 +108,7 @@ public abstract class YubicoClient {
      * @see YubicoClient#setClientId(Integer)
      */
     public String getKey() {
-        return new String(Base64.encodeBase64(this.key));
+        return DatatypeConverter.printBase64Binary(this.key);
     }
     
     /**


### PR DESCRIPTION
I don't see a reason to depend on the commons-codec library when there's a native Java 5 implementation of Base64 within the javax libs. This adds 240KBs of weight to the overall program which is unnecessary.