### PR TITLE
Updates to work better with new YubiCloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ pom.xml.versionsBackup
 
 *.iml
 .idea/
+
+### VSCode ###
+
+.vscode/

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,11 @@
 yubico-java-client NEWS -- History of user-visible changes.     -*- outline -*-
 
+* Version 3.1.0 (unreleased)
+ ** Updates to work better with new YubiCloud
+  *** Default YubiCloud URLs now include only `api.yubico.com`
+  *** `YubicoClient` now retries requests a number of times configurable via `.setMaxRetries(int)` (default: 5)
+  *** `YubicoClient` now logs warnings when deprecated URLs `api2.yubico.com ... api5.yubico.com` are used
+
 * Version 3.0.5
  ** Fixed runtime error on JRE 11 due to `javax.xml.bind.DatatypeConverter` not existing anymore
   *** Re-introduced `commons-codec` dependency.

--- a/demo-server/src/main/java/demo/Resource.java
+++ b/demo-server/src/main/java/demo/Resource.java
@@ -1,7 +1,6 @@
 package demo;
 
 import com.google.common.collect.HashMultimap;
-import com.yubico.client.v2.ResponseStatus;
 import com.yubico.client.v2.VerificationResponse;
 import com.yubico.client.v2.YubicoClient;
 

--- a/jaas/src/main/java/com/yubico/jaas/YubikeyLoginModule.java
+++ b/jaas/src/main/java/com/yubico/jaas/YubikeyLoginModule.java
@@ -31,6 +31,7 @@ package com.yubico.jaas;
 
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -184,13 +185,17 @@ public class YubikeyLoginModule implements LoginModule {
                 }
                 try {
                     log.debug("Trying to instantiate {}",usermap_class_name);
-                    this.ykmap = (YubikeyToUserMap) Class.forName(usermap_class_name).newInstance();
+                    this.ykmap = (YubikeyToUserMap) Class.forName(usermap_class_name).getDeclaredConstructor().newInstance();
                     this.ykmap.setOptions(options);
                 } catch (ClassNotFoundException ex) {
                     log.error("Could not create usermap from class " + usermap_class_name, ex);
                 } catch (InstantiationException ex) {
                     log.error("Could not create usermap from class " + usermap_class_name, ex);
                 } catch (IllegalAccessException ex) {
+                    log.error("Could not create usermap from class " + usermap_class_name, ex);
+                } catch (NoSuchMethodException ex) {
+                    log.error("Could not create usermap from class " + usermap_class_name, ex);
+                } catch (InvocationTargetException ex) {
                     log.error("Could not create usermap from class " + usermap_class_name, ex);
                 }
 	}

--- a/v2client/src/main/java/com/yubico/client/v2/VerificationRequester.java
+++ b/v2client/src/main/java/com/yubico/client/v2/VerificationRequester.java
@@ -45,7 +45,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
 
-import static com.yubico.client.v2.ResponseStatus.BACKEND_ERROR;;
+import static com.yubico.client.v2.ResponseStatus.BACKEND_ERROR;
 import static com.yubico.client.v2.ResponseStatus.REPLAYED_REQUEST;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/v2client/src/main/java/com/yubico/client/v2/VerificationRequester.java
+++ b/v2client/src/main/java/com/yubico/client/v2/VerificationRequester.java
@@ -174,7 +174,7 @@ public class VerificationRequester {
 			try {
 				return new VerificationResponseImpl(getResponseStream(url));
 			} catch (IOException e) {
-				log.warn("Exception when requesting {}: {}", url.getHost(), e.getMessage());
+				log.warn("Exception when requesting {}.", url.getHost(), e);
 				throw e;
 			}
 		}
@@ -191,7 +191,7 @@ public class VerificationRequester {
 					conn.setReadTimeout(15000);
 					return conn.getInputStream();
 				} catch (IOException e) {
-					log.warn("Exception when requesting {}, retrying: {}", url.getHost(), e.getMessage());
+					log.warn("Exception when requesting {}, retrying.", url.getHost(), e);
 					lastException = e;
 				}
 

--- a/v2client/src/main/java/com/yubico/client/v2/VerificationRequester.java
+++ b/v2client/src/main/java/com/yubico/client/v2/VerificationRequester.java
@@ -69,6 +69,16 @@ public class VerificationRequester {
 	}
 
 	/**
+	 * Alias of <code>fetch(urls, userAgent, 5)</code>.
+	 * @deprecated Use {@link #fetch(List, String, int)} with an explicit
+	 * <code>maxRetries</code> argument instead.
+	 */
+	@Deprecated
+	public VerificationResponse fetch(List<String> urls, String userAgent) throws YubicoVerificationException {
+		return fetch(urls, userAgent, 5);
+	}
+
+	/**
 	 * Fires off a validation request to each url in the list, returning the first one
 	 * that is not {@link ResponseStatus#REPLAYED_REQUEST}
 	 * 

--- a/v2client/src/main/java/com/yubico/client/v2/VerificationRequester.java
+++ b/v2client/src/main/java/com/yubico/client/v2/VerificationRequester.java
@@ -84,12 +84,16 @@ public class VerificationRequester {
 	 * 
 	 * @param urls a list of validation urls to be contacted
 	 * @param userAgent userAgent to send in request, if null one will be generated
-	 * @param maxRetries maximum number of retries in the case of network errors
+	 * @param maxRetries maximum number of retries in the case of network errors. Must not be negative.
 	 * @return {@link VerificationResponse} object from the first server response that is not
 	 * {@link ResponseStatus#REPLAYED_REQUEST}
 	 * @throws com.yubico.client.v2.exceptions.YubicoVerificationException if validation fails on all urls
 	 */
 	public VerificationResponse fetch(List<String> urls, String userAgent, int maxRetries) throws YubicoVerificationException {
+	    if (maxRetries < 0) {
+		throw new IllegalArgumentException("negative maxRetries is not valid.");
+	    }
+
 	    List<Future<VerificationResponse>> tasks = new ArrayList<Future<VerificationResponse>>();
 	    for(String url : urls) {
 			tasks.add(completionService.submit(createTask(userAgent, url, maxRetries)));
@@ -168,8 +172,12 @@ public class VerificationRequester {
 		 * Set up a VerifyTask for the Yubico Validation protocol v2
 		 * @param url the url to be used
 		 * @param userAgent the userAgent to be sent to the server, or NULL and one is calculated
+		 * @param maxRetries the maximum number of times to retry on network or server error
 		 */
 		public VerifyTask(String url, String userAgent, int maxRetries) {
+			if (maxRetries < 0) {
+				throw new IllegalArgumentException("negative maxRetries is not valid.");
+			}
 			this.url = url;
 			this.userAgent = userAgent;
 			this.maxRetries = maxRetries;

--- a/v2client/src/main/java/com/yubico/client/v2/YubicoClient.java
+++ b/v2client/src/main/java/com/yubico/client/v2/YubicoClient.java
@@ -123,9 +123,13 @@ public abstract class YubicoClient {
     /**
      * Set the maximum number of retries to attempt in the event of a network-related failure.
      * Default is 5.
-     * @param maxRetries maximum number of retries
+     * @param maxRetries maximum number of retries. Must not be negative.
      */
     public void setMaxRetries(int maxRetries) {
+        if (maxRetries < 0) {
+            throw new IllegalArgumentException("negative maxRetries is not valid.");
+        }
+
         this.maxRetries = maxRetries;
     }
     

--- a/v2client/src/main/java/com/yubico/client/v2/YubicoClient.java
+++ b/v2client/src/main/java/com/yubico/client/v2/YubicoClient.java
@@ -51,11 +51,7 @@ public abstract class YubicoClient {
     protected byte[] key;
     protected Integer sync;
     protected String wsapi_urls[] = {
-               "https://api.yubico.com/wsapi/2.0/verify",
-               "https://api2.yubico.com/wsapi/2.0/verify",
-               "https://api3.yubico.com/wsapi/2.0/verify",
-               "https://api4.yubico.com/wsapi/2.0/verify",
-               "https://api5.yubico.com/wsapi/2.0/verify"
+               "https://api.yubico.com/wsapi/2.0/verify"
     		};
     
     protected String userAgent = "yubico-java-client/" + Version.version +
@@ -147,6 +143,13 @@ public abstract class YubicoClient {
 	protected void warnIfDeprecatedUrl(String url) {
 		if (url != null && url.startsWith("http:")) {
 			log.warn("Deprecated YubiCloud URL: {} - naked HTTP requests are deprecated and will not be supported from 2019-02-04. See: https://status.yubico.com/2018/11/26/deprecating-yubicloud-v1-protocol-plain-text-requests-and-old-tls-versions/", url);
+		}
+		if (url != null &&
+                    (url.startsWith("https://api2.yubico.com/") ||
+                     url.startsWith("https://api3.yubico.com/") ||
+                     url.startsWith("https://api4.yubico.com/") ||
+                     url.startsWith("https://api5.yubico.com/"))) {
+			log.warn("Deprecated YubiCloud URL: {} - api2, api3, api4 and api5 are deprecated will not be supported from 2020-07-01. See: https://status.yubico.com/", url);
 		}
 	}
 	

--- a/v2client/src/main/java/com/yubico/client/v2/YubicoClient.java
+++ b/v2client/src/main/java/com/yubico/client/v2/YubicoClient.java
@@ -50,6 +50,7 @@ public abstract class YubicoClient {
     protected Integer clientId;
     protected byte[] key;
     protected Integer sync;
+    protected Integer maxRetries = 5;
     protected String wsapi_urls[] = {
                "https://api.yubico.com/wsapi/2.0/verify"
     		};
@@ -117,6 +118,15 @@ public abstract class YubicoClient {
      */
     public void setSync(Integer sync) {
     	this.sync = sync;
+    }
+
+    /**
+     * Set the maximum number of retries to attempt in the event of a network-related failure.
+     * Default is 5.
+     * @param maxRetries maximum number of retries
+     */
+    public void setMaxRetries(Integer maxRetries) {
+        this.maxRetries = maxRetries;
     }
     
     /**

--- a/v2client/src/main/java/com/yubico/client/v2/impl/YubicoClientImpl.java
+++ b/v2client/src/main/java/com/yubico/client/v2/impl/YubicoClientImpl.java
@@ -131,7 +131,7 @@ public class YubicoClientImpl extends YubicoClient {
             validationUrls.add(wsapiUrl + "?" + queryString);
         }
 
-        VerificationResponse response = validationService.fetch(validationUrls, userAgent);
+        VerificationResponse response = validationService.fetch(validationUrls, userAgent, maxRetries);
 
         if (key != null) {
             verifySignature(response);

--- a/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
+++ b/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
@@ -139,8 +139,8 @@ public class YubicoClientTest {
     	client.setWsapiUrls(new String[] {
 			"https://www.example.com/wsapi/2.0/verify",
 			"https://api2.example.com/wsapi/2.0/verify"
-    			});
-    	VerificationResponse response = client.verify(otp);
+        });
+    	client.verify(otp);
         fail("Expected exception to be thrown.");
     }
     
@@ -163,17 +163,17 @@ public class YubicoClientTest {
         YubicoClient client = new TestYubicoClientImpl(new VerificationRequester() {
             private boolean firstCall = true;
             @Override
-            protected VerifyTask createTask(String userAgent, String url) {
+            protected VerifyTask createTask(String userAgent, String url, int maxRetries) {
                 if (firstCall) {
                     firstCall = false;
-                    return new VerifyTask(url, userAgent) {
+                    return new VerifyTask(url, userAgent, maxRetries) {
                         @Override
                         protected InputStream getResponseStream(URL url) throws IOException {
                             return new ByteArrayInputStream("status=BACKEND_ERROR".getBytes("UTF-8"));
                         }
                     };
                 } else {
-                    return super.createTask(userAgent, url);
+                    return super.createTask(userAgent, url, maxRetries);
                 }
             }
         });

--- a/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
+++ b/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
@@ -73,15 +73,7 @@ public class YubicoClientTest {
 
     @Test
     public void testBadOTP() throws YubicoVerificationException, YubicoValidationFailure {
-        String otp="11111111111111111111111111111111111";
-        client.setWsapiUrls(new String[] {
-            // api.yubico.com is known to return bad signatures when given a bad OTP
-            // See https://github.com/Yubico/yubikey-val/issues/8
-            "https://api2.yubico.com/wsapi/2.0/verify",
-            "https://api3.yubico.com/wsapi/2.0/verify",
-            "https://api4.yubico.com/wsapi/2.0/verify",
-            "https://api3.yubico.com/wsapi/2.0/verify",
-        });
+    	String otp="11111111111111111111111111111111111";
         VerificationResponse response = client.verify(otp);
         assertNotNull(response);
         assertEquals(ResponseStatus.BAD_OTP, response.getStatus());
@@ -149,7 +141,7 @@ public class YubicoClientTest {
 			"https://api2.example.com/wsapi/2.0/verify"
     			});
     	VerificationResponse response = client.verify(otp);
-	fail("Expected exception to be thrown.");
+        fail("Expected exception to be thrown.");
     }
     
     @Test

--- a/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
+++ b/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
@@ -207,6 +207,11 @@ public class YubicoClientTest {
     public void testEmptyOTPPublicId() {
         YubicoClient.getPublicId("");
     }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testNegativeMaxRetries() {
+        client.setMaxRetries(-1);
+    }
     
     @Test
     public void testValidOTPPublicId() {

--- a/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
+++ b/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
@@ -166,6 +166,7 @@ public class YubicoClientTest {
             private boolean firstCall = true;
 
             @Override
+            @SuppressWarnings("deprecation")
             public VerificationResponse fetch(List<String> urls, String userAgent) throws YubicoVerificationException {
                 // Plain pass-through just to test that the signature is stable
                 return super.fetch(urls, userAgent);

--- a/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
+++ b/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
@@ -8,6 +8,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -162,6 +164,13 @@ public class YubicoClientTest {
 
         YubicoClient client = new TestYubicoClientImpl(new VerificationRequester() {
             private boolean firstCall = true;
+
+            @Override
+            public VerificationResponse fetch(List<String> urls, String userAgent) throws YubicoVerificationException {
+                // Plain pass-through just to test that the signature is stable
+                return super.fetch(urls, userAgent);
+            }
+
             @Override
             protected VerifyTask createTask(String userAgent, String url, int maxRetries) {
                 if (firstCall) {


### PR DESCRIPTION
The updated YubiCloud now does its own high availability and does not require parallel querying of several servers.

* Updates the defaults to just use api.yubico.com
* Prints deprecation warnings when api2..api5 are configured
* Adds retry logic, since we're not defaulting to 5 tries in parallel any more.
* A few cosmetic changes to make using VSCode with this repo easier